### PR TITLE
Exported WINEPREFIX for better readability

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -39,7 +39,7 @@ wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
 
 sh allredist/setup_vkd3d_proton.sh install
 mkdir -p "$WINEPREFIX/drive_c/Program Files/Adobe"
-mv Adobe\ Photoshop\ 2021 "$WINEPREFIX/drive_c/Program Files/Adobe/Adobe Photoshop 2021"
+mv "Adobe Photoshop 2021" "$WINEPREFIX/drive_c/Program Files/Adobe/Adobe Photoshop 2021"
 mv allredist/launcher.sh "$WINEPREFIX/drive_c"
 mv allredist/photoshop.png ~/.local/share/icons
 mv allredist/photoshop.desktop ~/.local/share/applications

--- a/installer.sh
+++ b/installer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export WINEPREFIX=~/.WineApps/Adobe-Photoshop
 echo "Welcome to Photoshop installer"
 echo "Would you like to install Camera Raw with photoshop? (This will prompt the camera raw installer at the end)"
 echo "1 - Yes, 0 - No"
@@ -11,9 +12,9 @@ mkdir ~/.WineApps/Adobe-Photoshop
 wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 chmod +x winetricks
 
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wineboot
+wineboot
 
-WINEPREFIX=~/.WineApps/Adobe-Photoshop ./winetricks win10
+./winetricks win10
 
 curl -L "https://drive.google.com/uc?export=download&id=1qcmyHzWerZ39OhW0y4VQ-hOy7639bJPO" > allredist.tar.xz
 mkdir allredist
@@ -24,20 +25,20 @@ tar -xf AdobePhotoshop2021.tar.xz
 rm -rf AdobePhotoshop2021.tar.xz
 
 
-WINEPREFIX=~/.WineApps/Adobe-Photoshop ./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine allredist/redist/2010/vcredist_x64.exe /q /norestart
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine allredist/redist/2010/vcredist_x86.exe /q /norestart
+./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk
+wine allredist/redist/2010/vcredist_x64.exe /q /norestart
+wine allredist/redist/2010/vcredist_x86.exe /q /norestart
 
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine allredist/redist/2012/vcredist_x86.exe /install /quiet /norestart
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine allredist/redist/2012/vcredist_x64.exe /install /quiet /norestart
+wine allredist/redist/2012/vcredist_x86.exe /install /quiet /norestart
+wine allredist/redist/2012/vcredist_x64.exe /install /quiet /norestart
 
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine allredist/redist/2013/vcredist_x86.exe /install /quiet /norestart
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine allredist/redist/2013/vcredist_x64.exe /install /quiet /norestart
+wine allredist/redist/2013/vcredist_x86.exe /install /quiet /norestart
+wine allredist/redist/2013/vcredist_x64.exe /install /quiet /norestart
 
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
+wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
+wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
 
-WINEPREFIX=~/.WineApps/Adobe-Photoshop sh allredist/setup_vkd3d_proton.sh install
+sh allredist/setup_vkd3d_proton.sh install
 mkdir ~/.WineApps/Adobe-Photoshop/drive_c/Program\ Files/Adobe
 mv Adobe\ Photoshop\ 2021 ~/.WineApps/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021
 mv allredist/launcher.sh ~/.WineApps/Adobe-Photoshop/drive_c
@@ -50,7 +51,7 @@ if [ $cameraraw = "1" ]
 then
 echo "Just follow the setup from Camera Raw..."
 curl -L "https://download.adobe.com/pub/adobe/photoshop/cameraraw/win/12.x/CameraRaw_12_2_1.exe" > CameraRaw_12_2_1.exe
-WINEPREFIX=~/.WineApps/Adobe-Photoshop wine CameraRaw_12_2_1.exe
+wine CameraRaw_12_2_1.exe
 rm -rf CameraRaw_12_2_1.exe
 else
 	echo ""

--- a/installer.sh
+++ b/installer.sh
@@ -6,8 +6,7 @@ echo "1 - Yes, 0 - No"
 cameraraw=1
 read cameraraw
 
-mkdir ~/.WineApps
-mkdir ~/.WineApps/Adobe-Photoshop
+mkdir -p "$WINEPREFIX"
 
 wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 chmod +x winetricks
@@ -39,9 +38,9 @@ wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
 wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
 
 sh allredist/setup_vkd3d_proton.sh install
-mkdir ~/.WineApps/Adobe-Photoshop/drive_c/Program\ Files/Adobe
-mv Adobe\ Photoshop\ 2021 ~/.WineApps/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021
-mv allredist/launcher.sh ~/.WineApps/Adobe-Photoshop/drive_c
+mkdir -p "$WINEPREFIX/drive_c/Program Files/Adobe"
+mv Adobe\ Photoshop\ 2021 "$WINEPREFIX/drive_c/Program Files/Adobe/Adobe Photoshop 2021"
+mv allredist/launcher.sh "$WINEPREFIX/drive_c"
 mv allredist/photoshop.png ~/.local/share/icons
 mv allredist/photoshop.desktop ~/.local/share/applications
 

--- a/scripts/photoshop2021install.sh
+++ b/scripts/photoshop2021install.sh
@@ -4,13 +4,14 @@ mkdir $1/Adobe-Photoshop
 wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 chmod +x winetricks
 
-WINEPREFIX=$1/Adobe-Photoshop wineboot
+export WINEPREFIX=$1/Adobe-Photoshop
+wineboot
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "10" >> $1/progress.mimifile
 
-WINEPREFIX=$1/Adobe-Photoshop ./winetricks win10
+./winetricks win10
 
 curl -L "https://drive.google.com/uc?export=download&id=1qcmyHzWerZ39OhW0y4VQ-hOy7639bJPO" > allredist.tar.xz
 mkdir allredist
@@ -41,31 +42,31 @@ touch $1/progress.mimifile
 echo "70" >> $1/progress.mimifile
 
 
-WINEPREFIX=$1/Adobe-Photoshop ./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk win10
+./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk win10
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "80" >> $1/progress.mimifile
 
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2010/vcredist_x64.exe /q /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2010/vcredist_x86.exe /q /norestart
+wine allredist/redist/2010/vcredist_x64.exe /q /norestart
+wine allredist/redist/2010/vcredist_x86.exe /q /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2012/vcredist_x86.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2012/vcredist_x64.exe /install /quiet /norestart
+wine allredist/redist/2012/vcredist_x86.exe /install /quiet /norestart
+wine allredist/redist/2012/vcredist_x64.exe /install /quiet /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2013/vcredist_x86.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2013/vcredist_x64.exe /install /quiet /norestart
+wine allredist/redist/2013/vcredist_x86.exe /install /quiet /norestart
+wine allredist/redist/2013/vcredist_x64.exe /install /quiet /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
+wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
+wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
 
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "90" >> $1/progress.mimifile
 
-WINEPREFIX=$1/Adobe-Photoshop sh allredist/setup_vkd3d_proton.sh install
+sh allredist/setup_vkd3d_proton.sh install
 
 
 mkdir $1/Adobe-Photoshop/drive_c/Program\ Files/Adobe
@@ -83,7 +84,7 @@ echo 'WINEPREFIX='$1'/Adobe-Photoshop DXVK_LOG_PATH='$1'/Adobe-Photoshop DXVK_ST
 
 chmod +x $1/Adobe-Photoshop/drive_c/launcher.sh
 
-WINEPREFIX=$1/Adobe-Photoshop winecfg -v win10
+winecfg -v win10
 
 
 mv allredist/photoshop.png ~/.local/share/icons

--- a/scripts/photoshop2021install.sh
+++ b/scripts/photoshop2021install.sh
@@ -68,8 +68,8 @@ echo "90" >> $1/progress.mimifile
 sh allredist/setup_vkd3d_proton.sh install
 
 
-mkdir "$WINEPREFIX/drive_c/Program\ Files/Adobe"
-mv Adobe\ Photoshop\ 2021 "$WINEPREFIX/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021"
+mkdir "$WINEPREFIX/drive_c/Program Files/Adobe"
+mv "Adobe Photoshop 2021" "$WINEPREFIX/drive_c/Program Files/Adobe/Adobe Photoshop 2021"
 
 touch "$WINEPREFIX/drive_c/launcher.sh"
 echo '#!/usr/bin/env bash' >> "$WINEPREFIX/drive_c/launcher.sh"
@@ -79,7 +79,7 @@ echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'FILE_PATH=$(winepath -w "$1")' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'export WINEPREFIX="'$WINEPREFIX'"' >> "$WINEPREFIX/drive_c/launcher.sh"
-echo 'WINEPREFIX="'$WINEPREFIX'" DXVK_LOG_PATH="'$WINEPREFIX'" DXVK_STATE_CACHE_PATH="'$WINEPREFIX'" wine64 ' $WINEPREFIX'/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021/photoshop.exe $FILE_PATH' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINEPREFIX="'$WINEPREFIX'" DXVK_LOG_PATH="'$WINEPREFIX'" DXVK_STATE_CACHE_PATH="'$WINEPREFIX'" wine64 ' $WINEPREFIX'/drive_c/Progra\ Files/Adobe/Adobe Photoshop 2021/photoshop.exe $FILE_PATH' >> "$WINEPREFIX/drive_c/launcher.sh"
 
 chmod +x $WINEPREFIX/drive_c/launcher.sh
 

--- a/scripts/photoshop2021install.sh
+++ b/scripts/photoshop2021install.sh
@@ -1,10 +1,9 @@
 
-mkdir $1/Adobe-Photoshop
-
 wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 chmod +x winetricks
 
 export WINEPREFIX=$1/Adobe-Photoshop
+mkdir -p "$WINEPREFIX"
 wineboot
 
 rm -rf $1/progress.mimifile
@@ -69,20 +68,20 @@ echo "90" >> $1/progress.mimifile
 sh allredist/setup_vkd3d_proton.sh install
 
 
-mkdir $1/Adobe-Photoshop/drive_c/Program\ Files/Adobe
-mv Adobe\ Photoshop\ 2021 $1/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021
+mkdir "$WINEPREFIX/drive_c/Program\ Files/Adobe"
+mv Adobe\ Photoshop\ 2021 "$WINEPREFIX/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021"
 
-touch $1/Adobe-Photoshop/drive_c/launcher.sh
-echo '#!/usr/bin/env bash' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'SCR_PATH="pspath"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'CACHE_PATH="pscache"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'FILE_PATH=$(winepath -w "$1")' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'export WINEPREFIX="'$1'/Adobe-Photoshop"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'WINEPREFIX='$1'/Adobe-Photoshop DXVK_LOG_PATH='$1'/Adobe-Photoshop DXVK_STATE_CACHE_PATH='$1'/Adobe-Photoshop wine64 ' $1'/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021/photoshop.exe $FILE_PATH' >> $1/Adobe-Photoshop/drive_c/launcher.sh
+touch "$WINEPREFIX/drive_c/launcher.sh"
+echo '#!/usr/bin/env bash' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'SCR_PATH="pspath"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'CACHE_PATH="pscache"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'FILE_PATH=$(winepath -w "$1")' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'export WINEPREFIX="'$WINEPREFIX'"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINEPREFIX="'$WINEPREFIX'" DXVK_LOG_PATH="'$WINEPREFIX'" DXVK_STATE_CACHE_PATH="'$WINEPREFIX'" wine64 ' $WINEPREFIX'/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021/photoshop.exe $FILE_PATH' >> "$WINEPREFIX/drive_c/launcher.sh"
 
-chmod +x $1/Adobe-Photoshop/drive_c/launcher.sh
+chmod +x $WINEPREFIX/drive_c/launcher.sh
 
 winecfg -v win10
 
@@ -93,7 +92,7 @@ mv allredist/photoshop.png ~/.local/share/icons
 touch ~/.local/share/applications/photoshop.desktop
 echo '[Desktop Entry]' >> ~/.local/share/applications/photoshop.desktop
 echo 'Name=Photoshop CC 2021' >> ~/.local/share/applications/photoshop.desktop
-echo 'Exec=bash -c "'$1'/Adobe-Photoshop/drive_c/launcher.sh %F"' >> ~/.local/share/applications/photoshop.desktop
+echo 'Exec=bash -c "'$WINEPREFIX'/drive_c/launcher.sh %F"' >> ~/.local/share/applications/photoshop.desktop
 echo 'Type=Application' >> ~/.local/share/applications/photoshop.desktop
 echo 'Comment=Photoshop CC 2021 (Wine)' >> ~/.local/share/applications/photoshop.desktop
 echo 'Categories=Graphics;' >> ~/.local/share/applications/photoshop.desktop

--- a/scripts/photoshop2021installcr.sh
+++ b/scripts/photoshop2021installcr.sh
@@ -4,13 +4,14 @@ mkdir $1/Adobe-Photoshop
 wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 chmod +x winetricks
 
-WINEPREFIX=$1/Adobe-Photoshop wineboot
+export WINEPREFIX=$1/Adobe-Photoshop
+wineboot
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "10" >> $1/progress.mimifile
 
-WINEPREFIX=$1/Adobe-Photoshop ./winetricks win10
+./winetricks win10
 
 curl -L "https://drive.google.com/uc?export=download&id=1qcmyHzWerZ39OhW0y4VQ-hOy7639bJPO" > allredist.tar.xz
 mkdir allredist
@@ -41,31 +42,31 @@ touch $1/progress.mimifile
 echo "70" >> $1/progress.mimifile
 
 
-WINEPREFIX=$1/Adobe-Photoshop ./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk win10
+./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk win10
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "80" >> $1/progress.mimifile
 
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2010/vcredist_x64.exe /q /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2010/vcredist_x86.exe /q /norestart
+wine allredist/redist/2010/vcredist_x64.exe /q /norestart
+wine allredist/redist/2010/vcredist_x86.exe /q /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2012/vcredist_x86.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2012/vcredist_x64.exe /install /quiet /norestart
+wine allredist/redist/2012/vcredist_x86.exe /install /quiet /norestart
+wine allredist/redist/2012/vcredist_x64.exe /install /quiet /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2013/vcredist_x86.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2013/vcredist_x64.exe /install /quiet /norestart
+wine allredist/redist/2013/vcredist_x86.exe /install /quiet /norestart
+wine allredist/redist/2013/vcredist_x64.exe /install /quiet /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
+wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
+wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
 
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "90" >> $1/progress.mimifile
 
-WINEPREFIX=$1/Adobe-Photoshop sh allredist/setup_vkd3d_proton.sh install
+sh allredist/setup_vkd3d_proton.sh install
 
 
 mkdir $1/Adobe-Photoshop/drive_c/Program\ Files/Adobe
@@ -83,7 +84,7 @@ echo 'WINEPREFIX='$1'/Adobe-Photoshop DXVK_LOG_PATH='$1'/Adobe-Photoshop DXVK_ST
 
 chmod +x $1/Adobe-Photoshop/drive_c/launcher.sh
 
-WINEPREFIX=$1/Adobe-Photoshop winecfg -v win10
+winecfg -v win10
 
 
 mv allredist/photoshop.png ~/.local/share/icons
@@ -108,7 +109,7 @@ touch $1/progress.mimifile
 echo "95" >> $1/progress.mimifile
 
 curl -L "https://download.adobe.com/pub/adobe/photoshop/cameraraw/win/12.x/CameraRaw_12_2_1.exe" > CameraRaw_12_2_1.exe 
-WINEPREFIX=$1/Adobe-Photoshop wine CameraRaw_12_2_1.exe
+wine CameraRaw_12_2_1.exe
 rm -rf CameraRaw_12_2_1.exe
 
 rm -rf $1/progress.mimifile

--- a/scripts/photoshop2021installcr.sh
+++ b/scripts/photoshop2021installcr.sh
@@ -1,10 +1,9 @@
 
-mkdir $1/Adobe-Photoshop
-
 wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 chmod +x winetricks
 
 export WINEPREFIX=$1/Adobe-Photoshop
+mkdir -p "$WINEPREFIX"
 wineboot
 
 rm -rf $1/progress.mimifile
@@ -69,20 +68,19 @@ echo "90" >> $1/progress.mimifile
 sh allredist/setup_vkd3d_proton.sh install
 
 
-mkdir $1/Adobe-Photoshop/drive_c/Program\ Files/Adobe
-mv Adobe\ Photoshop\ 2021 $1/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021
+mkdir "$WINEPREFIX/drive_c/Program\ Files/Adobe"
+mv Adobe\ Photoshop\ 2021 "$WINEPREFIX/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021"
 
-touch $1/Adobe-Photoshop/drive_c/launcher.sh
-echo '#!/usr/bin/env bash' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'SCR_PATH="pspath"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'CACHE_PATH="pscache"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'FILE_PATH=$(winepath -w "$1")' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'export WINEPREFIX="'$1'/Adobe-Photoshop"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'WINEPREFIX='$1'/Adobe-Photoshop DXVK_LOG_PATH='$1'/Adobe-Photoshop DXVK_STATE_CACHE_PATH='$1'/Adobe-Photoshop wine64 ' $1'/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021/photoshop.exe $FILE_PATH' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-
-chmod +x $1/Adobe-Photoshop/drive_c/launcher.sh
+touch "$WINEPREFIX/drive_c/launcher.sh"
+echo '#!/usr/bin/env bash' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'SCR_PATH="pspath"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'CACHE_PATH="pscache"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'FILE_PATH=$(winepath -w "$1")' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'export WINEPREFIX="'$WINEPREFIX'"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINEPREFIX="'$WINEPREFIX'" DXVK_LOG_PATH="'$WINEPREFIX'" DXVK_STATE_CACHE_PATH="'$WINEPREFIX'" wine64 ' $WINEPREFIX'/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021/photoshop.exe $FILE_PATH' >> "$WINEPREFIX/drive_c/launcher.sh"
+chmod +x "$WINEPREFIX/drive_c/launcher.sh"
 
 winecfg -v win10
 
@@ -93,7 +91,7 @@ mv allredist/photoshop.png ~/.local/share/icons
 touch ~/.local/share/applications/photoshop.desktop
 echo '[Desktop Entry]' >> ~/.local/share/applications/photoshop.desktop
 echo 'Name=Photoshop CC 2021' >> ~/.local/share/applications/photoshop.desktop
-echo 'Exec=bash -c "'$1'/Adobe-Photoshop/drive_c/launcher.sh %F"' >> ~/.local/share/applications/photoshop.desktop
+echo 'Exec=bash -c "'$WINEPREFIX'/drive_c/launcher.sh %F"' >> ~/.local/share/applications/photoshop.desktop
 echo 'Type=Application' >> ~/.local/share/applications/photoshop.desktop
 echo 'Comment=Photoshop CC 2021 (Wine)' >> ~/.local/share/applications/photoshop.desktop
 echo 'Categories=Graphics;' >> ~/.local/share/applications/photoshop.desktop

--- a/scripts/photoshop2021installcr.sh
+++ b/scripts/photoshop2021installcr.sh
@@ -68,8 +68,8 @@ echo "90" >> $1/progress.mimifile
 sh allredist/setup_vkd3d_proton.sh install
 
 
-mkdir "$WINEPREFIX/drive_c/Program\ Files/Adobe"
-mv Adobe\ Photoshop\ 2021 "$WINEPREFIX/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021"
+mkdir "$WINEPREFIX/drive_c/Program Files/Adobe"
+mv "Adobe Photoshop 2021" "$WINEPREFIX/drive_c/Program Files/Adobe/Adobe Photoshop 2021"
 
 touch "$WINEPREFIX/drive_c/launcher.sh"
 echo '#!/usr/bin/env bash' >> "$WINEPREFIX/drive_c/launcher.sh"
@@ -79,7 +79,7 @@ echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'FILE_PATH=$(winepath -w "$1")' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'export WINEPREFIX="'$WINEPREFIX'"' >> "$WINEPREFIX/drive_c/launcher.sh"
-echo 'WINEPREFIX="'$WINEPREFIX'" DXVK_LOG_PATH="'$WINEPREFIX'" DXVK_STATE_CACHE_PATH="'$WINEPREFIX'" wine64 ' $WINEPREFIX'/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021/photoshop.exe $FILE_PATH' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINEPREFIX="'$WINEPREFIX'" DXVK_LOG_PATH="'$WINEPREFIX'" DXVK_STATE_CACHE_PATH="'$WINEPREFIX'" wine64 ' $WINEPREFIX'/drive_c/Program Files/Adobe/Adobe Photoshop 2021/photoshop.exe $FILE_PATH' >> "$WINEPREFIX/drive_c/launcher.sh"
 chmod +x "$WINEPREFIX/drive_c/launcher.sh"
 
 winecfg -v win10

--- a/scripts/photoshop2022install.sh
+++ b/scripts/photoshop2022install.sh
@@ -72,8 +72,8 @@ rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "90" >> $1/progress.mimifile
 
-mkdir -p "$WINEPREFIX/drive_c/Program\ Files/Adobe"
-mv Adobe\ Photoshop\ 2022 "$WINEPREFIX/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2022"
+mkdir -p "$WINEPREFIX/drive_c/Program Files/Adobe"
+mv "Adobe Photoshop 2022" "$WINEPREFIX/drive_c/Program Files/Adobe/Adobe Photoshop 2022"
 
 touch "$WINEPREFIX/drive_c/launcher.sh"
 echo '#!/usr/bin/env bash' >> "$WINEPREFIX/drive_c/launcher.sh"
@@ -83,11 +83,11 @@ echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'FILE_PATH=$(winepath -w "$1")' >> "$WINEPREFIX/drive_c/launcher.sh"
 echo 'export WINEPREFIX="'$WINEPREFIX'"' >> "$WINEPREFIX/drive_c/launcher.sh"
-echo 'WINEPREFIX='$WINEPREFIX' DXVK_LOG_PATH='$WINEPREFIX' DXVK_STATE_CACHE_PATH='$WINEPREFIX' wine64 ' $WINEPREFIX'/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2022/photoshop.exe $FILE_PATH' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINEPREFIX='$WINEPREFIX' DXVK_LOG_PATH='$WINEPREFIX' DXVK_STATE_CACHE_PATH='$WINEPREFIX' wine64 "'$WINEPREFIX'/drive_c/Program Files/Adobe/Adobe Photoshop 2022/photoshop.exe" '$FILE_PATH'' >> "$WINEPREFIX/drive_c/launcher.sh"
 
 chmod +x "$WINEPREFIX/drive_c/launcher.sh"
 
-rm -rf Adobe\ Photoshop\ 2022
+rm -rf "Adobe Photoshop 2022"
 
 winecfg -v win10
 
@@ -99,9 +99,9 @@ curl -L "https://lulucloud.mywire.org/FileHosting/GithubProjects/PS2022/Adobe_Ph
 tar -xf Adobe_Photoshop_2022_Settings.tar.xz
 mkdir "$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/Adobe"
 mkdir "$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/Adobe/Adobe Photoshop 2022/"
-mv Adobe\ Photoshop\ 2022\ Settings "$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/Adobe/Adobe\ Photoshop\ 2022/"
+mv "Adobe Photoshop 2022 Settings" "$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/Adobe/Adobe Photoshop 2022/"
 rm -rf Adobe_Photoshop_2022_Settings.tar.xz
-rm -rf Adobe\ Photoshop\ 2022\ Settings
+rm -rf "Adobe Photoshop 2022 Settings"
 
 
 touch ~/.local/share/applications/photoshop.desktop

--- a/scripts/photoshop2022install.sh
+++ b/scripts/photoshop2022install.sh
@@ -4,13 +4,14 @@ mkdir $1/Adobe-Photoshop
 wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 chmod +x winetricks
 
-WINEPREFIX=$1/Adobe-Photoshop wineboot
+export WINEPREFIX=$1/Adobe-Photoshop
+wineboot
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "10" >> $1/progress.mimifile
 
-WINEPREFIX=$1/Adobe-Photoshop ./winetricks win10
+./winetricks win10
 
 curl -L "https://lulucloud.mywire.org/FileHosting/GithubProjects/PS2022/allredist.tar.xz" > allredist.tar.xz
 mkdir allredist
@@ -47,24 +48,24 @@ touch $1/progress.mimifile
 echo "70" >> $1/progress.mimifile
 
 
-WINEPREFIX=$1/Adobe-Photoshop ./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk win10
+./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk win10
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "80" >> $1/progress.mimifile
 
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2010/vcredist_x64.exe /q /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2010/vcredist_x86.exe /q /norestart
+wine allredist/redist/2010/vcredist_x64.exe /q /norestart
+wine allredist/redist/2010/vcredist_x86.exe /q /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2012/vcredist_x86.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2012/vcredist_x64.exe /install /quiet /norestart
+wine allredist/redist/2012/vcredist_x86.exe /install /quiet /norestart
+wine allredist/redist/2012/vcredist_x64.exe /install /quiet /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2013/vcredist_x86.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2013/vcredist_x64.exe /install /quiet /norestart
+wine allredist/redist/2013/vcredist_x86.exe /install /quiet /norestart
+wine allredist/redist/2013/vcredist_x64.exe /install /quiet /norestart
 
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
-WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
+wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
+wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
 
 
 rm -rf $1/progress.mimifile
@@ -88,7 +89,7 @@ chmod +x $1/Adobe-Photoshop/drive_c/launcher.sh
 
 rm -rf Adobe\ Photoshop\ 2022
 
-WINEPREFIX=$1/Adobe-Photoshop winecfg -v win10
+winecfg -v win10
 
 
 mv allredist/photoshop.png ~/.local/share/icons

--- a/scripts/photoshop2022install.sh
+++ b/scripts/photoshop2022install.sh
@@ -1,10 +1,9 @@
 
-mkdir $1/Adobe-Photoshop
-
 wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 chmod +x winetricks
 
 export WINEPREFIX=$1/Adobe-Photoshop
+mkdir -p "$WINEPREFIX"
 wineboot
 
 rm -rf $1/progress.mimifile
@@ -31,7 +30,8 @@ curl -L "https://lulucloud.mywire.org/FileHosting/GithubProjects/PS2022/AdobePho
 
 curl -L "https://lulucloud.mywire.org/FileHosting/GithubProjects/PS2022/Adobe.tar.xz" > Adobe.tar.xz
 tar -xf Adobe.tar.xz
-mv Adobe $1/Adobe-Photoshop/drive_c/Program\ Files\ \(x86\)/Common\ Files
+mkdir -p "$WINEPREFIX/drive_c/Program Files (x86)/Common Files"
+mv Adobe "$WINEPREFIX/drive_c/Program Files (x86)/Common Files"
 rm -rf Adobe.tar.xz
 rm -rf Adobe
 
@@ -72,20 +72,20 @@ rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "90" >> $1/progress.mimifile
 
-mkdir $1/Adobe-Photoshop/drive_c/Program\ Files/Adobe
-mv Adobe\ Photoshop\ 2022 $1/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2022
+mkdir -p "$WINEPREFIX/drive_c/Program\ Files/Adobe"
+mv Adobe\ Photoshop\ 2022 "$WINEPREFIX/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2022"
 
-touch $1/Adobe-Photoshop/drive_c/launcher.sh
-echo '#!/usr/bin/env bash' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'SCR_PATH="pspath"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'CACHE_PATH="pscache"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'FILE_PATH=$(winepath -w "$1")' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'export WINEPREFIX="'$1'/Adobe-Photoshop"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'WINEPREFIX='$1'/Adobe-Photoshop DXVK_LOG_PATH='$1'/Adobe-Photoshop DXVK_STATE_CACHE_PATH='$1'/Adobe-Photoshop wine64 ' $1'/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2022/photoshop.exe $FILE_PATH' >> $1/Adobe-Photoshop/drive_c/launcher.sh
+touch "$WINEPREFIX/drive_c/launcher.sh"
+echo '#!/usr/bin/env bash' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'SCR_PATH="pspath"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'CACHE_PATH="pscache"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'FILE_PATH=$(winepath -w "$1")' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'export WINEPREFIX="'$WINEPREFIX'"' >> "$WINEPREFIX/drive_c/launcher.sh"
+echo 'WINEPREFIX='$WINEPREFIX' DXVK_LOG_PATH='$WINEPREFIX' DXVK_STATE_CACHE_PATH='$WINEPREFIX' wine64 ' $WINEPREFIX'/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2022/photoshop.exe $FILE_PATH' >> "$WINEPREFIX/drive_c/launcher.sh"
 
-chmod +x $1/Adobe-Photoshop/drive_c/launcher.sh
+chmod +x "$WINEPREFIX/drive_c/launcher.sh"
 
 rm -rf Adobe\ Photoshop\ 2022
 
@@ -97,9 +97,9 @@ mv allredist/photoshop.png ~/.local/share/icons
 
 curl -L "https://lulucloud.mywire.org/FileHosting/GithubProjects/PS2022/Adobe_Photoshop_2022_Settings.tar.xz" > Adobe_Photoshop_2022_Settings.tar.xz
 tar -xf Adobe_Photoshop_2022_Settings.tar.xz
-mkdir $1/Adobe-Photoshop/drive_c/users/$USER/AppData/Roaming/Adobe
-mkdir $1/Adobe-Photoshop/drive_c/users/$USER/AppData/Roaming/Adobe/Adobe\ Photoshop\ 2022/
-mv Adobe\ Photoshop\ 2022\ Settings $1/Adobe-Photoshop/drive_c/users/$USER/AppData/Roaming/Adobe/Adobe\ Photoshop\ 2022/
+mkdir "$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/Adobe"
+mkdir "$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/Adobe/Adobe Photoshop 2022/"
+mv Adobe\ Photoshop\ 2022\ Settings "$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/Adobe/Adobe\ Photoshop\ 2022/"
 rm -rf Adobe_Photoshop_2022_Settings.tar.xz
 rm -rf Adobe\ Photoshop\ 2022\ Settings
 
@@ -107,7 +107,7 @@ rm -rf Adobe\ Photoshop\ 2022\ Settings
 touch ~/.local/share/applications/photoshop.desktop
 echo '[Desktop Entry]' >> ~/.local/share/applications/photoshop.desktop
 echo 'Name=Photoshop CC 2022' >> ~/.local/share/applications/photoshop.desktop
-echo 'Exec=bash -c "'$1'/Adobe-Photoshop/drive_c/launcher.sh %F"' >> ~/.local/share/applications/photoshop.desktop
+echo 'Exec=bash -c "'$WINEPREFIX'/drive_c/launcher.sh %F"' >> ~/.local/share/applications/photoshop.desktop
 echo 'Type=Application' >> ~/.local/share/applications/photoshop.desktop
 echo 'Comment=Photoshop CC 2022 (Wine)' >> ~/.local/share/applications/photoshop.desktop
 echo 'Categories=Graphics;' >> ~/.local/share/applications/photoshop.desktop

--- a/uninstaller.sh
+++ b/uninstaller.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-rm -rf ~/.WineApps/Adobe-Photoshop
+export WINEPREFIX=~/.WineApps/Adobe-Photoshop
+
+rm -rf "$WINEPREFIX"
 rm -rf ~/.local/share/icons/photoshop.png
 rm -rf  ~/.local/share/applications/photoshop.desktop
 


### PR DESCRIPTION
Using `WINEPREFIX=~/.WineApps/Adobe-Photoshop` in every wine related operation is not a good idea.

In this pr, that problem was fixed with exporting WINEPREFIX variable in scripts.