### PR TITLE
Fixed install script syntax error

### DIFF
--- a/scripts/photoshop2021install.sh
+++ b/scripts/photoshop2021install.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/bin/bash
 
 mkdir $1/Adobe-Photoshop
 


### PR DESCRIPTION
Fixed the script not executing due to a missing symbol causing a bash "Bad interpreter" error.